### PR TITLE
Fix duplicate logger definition

### DIFF
--- a/src/csv_to_xml_converter/xml_generator/__init__.py
+++ b/src/csv_to_xml_converter/xml_generator/__init__.py
@@ -21,8 +21,6 @@ from .xml_parsing_utils import (
 )
 
 
-logger = logging.getLogger(__name__)
-
 # --- Namespaces (Consistent with successful prior states) ---
 MHLW_NS_URL = "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000161103.html"
 XSI_NS = "http://www.w3.org/2001/XMLSchema-instance"


### PR DESCRIPTION
## Summary
- remove redundant logger reassignment in `xml_generator/__init__.py`

## Testing
- `pyflakes src/csv_to_xml_converter/xml_generator/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844d6a93c088333a2c3937dc9fe2e2e