### PR TITLE
Implement new rule engine features and configs

### DIFF
--- a/config_rules/index_rules.json
+++ b/config_rules/index_rules.json
@@ -1,0 +1,10 @@
+[
+  {"rule_type": "default_value", "output_field": "interactionType", "value": "1"},
+  {"rule_type": "data_type_conversion", "input_field": "creation_date", "output_field": "creationTime", "conversion_type": "to_date_yyyymmdd"},
+  {"rule_type": "default_value", "output_field": "senderIdRootOid", "value": "1.2.392.100000.6.9999"},
+  {"rule_type": "default_value", "output_field": "senderIdExtension", "value": "SENDER_ORG_ID_001"},
+  {"rule_type": "default_value", "output_field": "receiverIdRootOid", "value": "1.2.392.200000.6.8888"},
+  {"rule_type": "default_value", "output_field": "receiverIdExtension", "value": "RECEIVER_ORG_ID_001"},
+  {"rule_type": "default_value", "output_field": "serviceEventType", "value": "1"},
+  {"rule_type": "data_type_conversion", "input_field": "record_count", "output_field": "totalRecordCount", "conversion_type": "to_integer"}
+]

--- a/config_rules/summary_rules.json
+++ b/config_rules/summary_rules.json
@@ -1,0 +1,10 @@
+[
+  {"rule_type": "default_value", "output_field": "serviceEventTypeCode", "value": "AGG_SUMMARY"},
+  {"rule_type": "default_value", "output_field": "serviceEventTypeCodeSystem", "value": "1.2.392.100000.6.9999.1"},
+  {"rule_type": "default_value", "output_field": "serviceEventTypeDisplayName", "value": "集計サマリー"},
+  {"rule_type": "data_type_conversion", "input_field": "total_subjects", "output_field": "totalSubjectCount", "conversion_type": "to_integer"},
+  {"rule_type": "data_type_conversion", "input_field": "total_cost", "output_field": "totalCostAmount_value", "conversion_type": "to_integer"},
+  {"rule_type": "default_value", "output_field": "totalCostAmount_currency", "value": "JPY"},
+  {"rule_type": "data_type_conversion", "input_field": "total_claim", "output_field": "totalClaimAmount_value", "conversion_type": "to_integer"},
+  {"rule_type": "default_value", "output_field": "totalClaimAmount_currency", "value": "JPY"}
+]


### PR DESCRIPTION
## Summary
- support `concat`, `split`, and `create_nested_object` rule types
- auto-load `$oid_catalog$` lookups in `apply_rules`
- add index and summary rule files
- extend rule engine tests for new features

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453671061c8333ae14c0cde9d1a371