### PR TITLE
Add orchestrator aggregation and tests

### DIFF
--- a/config_rules/index_rules.json
+++ b/config_rules/index_rules.json
@@ -1,10 +1,10 @@
 [
   {"rule_type": "default_value", "output_field": "interactionType", "value": "1"},
   {"rule_type": "data_type_conversion", "input_field": "creation_date", "output_field": "creationTime", "conversion_type": "to_date_yyyymmdd"},
-  {"rule_type": "default_value", "output_field": "senderIdRootOid", "value": "1.2.392.100000.6.9999"},
-  {"rule_type": "default_value", "output_field": "senderIdExtension", "value": "SENDER_ORG_ID_001"},
-  {"rule_type": "default_value", "output_field": "receiverIdRootOid", "value": "1.2.392.200000.6.8888"},
-  {"rule_type": "default_value", "output_field": "receiverIdExtension", "value": "RECEIVER_ORG_ID_001"},
+  {"rule_type": "default_value", "output_field": "senderIdRootOid", "value": "1.2.392.200119.6.102"},
+  {"rule_type": "default_value", "output_field": "senderIdExtension", "value": "0000000000"},
+  {"rule_type": "default_value", "output_field": "receiverIdRootOid", "value": "1.2.392.200119.6.105"},
+  {"rule_type": "default_value", "output_field": "receiverIdExtension", "value": "1111111111"},
   {"rule_type": "default_value", "output_field": "serviceEventType", "value": "1"},
   {"rule_type": "data_type_conversion", "input_field": "record_count", "output_field": "totalRecordCount", "conversion_type": "to_integer"}
 ]

--- a/config_rules/summary_rules.json
+++ b/config_rules/summary_rules.json
@@ -1,10 +1,12 @@
 [
-  {"rule_type": "default_value", "output_field": "serviceEventTypeCode", "value": "AGG_SUMMARY"},
-  {"rule_type": "default_value", "output_field": "serviceEventTypeCodeSystem", "value": "1.2.392.100000.6.9999.1"},
+  {"rule_type": "default_value", "output_field": "serviceEventTypeCode", "value": "1"},
+  {"rule_type": "default_value", "output_field": "serviceEventTypeCodeSystem", "value": "1.2.392.200119.6.1001"},
   {"rule_type": "default_value", "output_field": "serviceEventTypeDisplayName", "value": "集計サマリー"},
-  {"rule_type": "data_type_conversion", "input_field": "total_subjects", "output_field": "totalSubjectCount", "conversion_type": "to_integer"},
-  {"rule_type": "data_type_conversion", "input_field": "total_cost", "output_field": "totalCostAmount_value", "conversion_type": "to_integer"},
+  {"rule_type": "data_type_conversion", "input_field": "total_subjects", "output_field": "totalSubjectCount_value", "conversion_type": "to_integer"},
+  {"rule_type": "data_type_conversion", "input_field": "total_cost", "output_field": "totalCostAmountValue", "conversion_type": "to_integer"},
   {"rule_type": "default_value", "output_field": "totalCostAmount_currency", "value": "JPY"},
-  {"rule_type": "data_type_conversion", "input_field": "total_claim", "output_field": "totalClaimAmount_value", "conversion_type": "to_integer"},
+  {"rule_type": "data_type_conversion", "input_field": "total_claim", "output_field": "totalPaymentAmountValue", "conversion_type": "to_integer"},
+  {"rule_type": "default_value", "output_field": "totalPaymentAmount_currency", "value": "JPY"},
+  {"rule_type": "data_type_conversion", "input_field": "total_claim", "output_field": "totalClaimAmountValue", "conversion_type": "to_integer"},
   {"rule_type": "default_value", "output_field": "totalClaimAmount_currency", "value": "JPY"}
 ]

--- a/tests/test_orchestrator_aggregation.py
+++ b/tests/test_orchestrator_aggregation.py
@@ -1,0 +1,44 @@
+import os
+from lxml import etree
+from csv_to_xml_converter.orchestrator import Orchestrator
+
+
+def test_orchestrator_aggregation(tmp_path):
+    cda_path = tmp_path / "cda.xml"
+    cda_path.write_text(
+        "<cda:ClinicalDocument xmlns:cda=\"urn:hl7-org:v3\"></cda:ClinicalDocument>",
+        encoding="utf-8",
+    )
+    cc08_path = tmp_path / "cc08.xml"
+    cc08_path.write_text(
+        "<checkupClaim xmlns=\"https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000161103.html\"><settlement><claimAmount value=\"1500\"/></settlement></checkupClaim>",
+        encoding="utf-8",
+    )
+    gc08_path = tmp_path / "gc08.xml"
+    gc08_path.write_text(
+        "<gc:GuidanceClaimDocument xmlns:gc=\"urn:MHLW:guidance:claim:GC:2021\"><gc:settlementDetails><gc:claimAmount value=\"2500\"/></gc:settlementDetails></gc:GuidanceClaimDocument>",
+        encoding="utf-8",
+    )
+
+    config = {
+        "rule_files": {
+            "index_rules": os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "config_rules", "index_rules.json")),
+            "summary_rules": os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "config_rules", "summary_rules.json")),
+        }
+    }
+    orch = Orchestrator(config)
+    index_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "XSD", "ix08_V08.xsd"))
+    summary_xsd = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "XSD", "su08_V08.xsd"))
+    index_out = tmp_path / "index.xml"
+    summary_out = tmp_path / "summary.xml"
+
+    assert orch.generate_aggregated_index_xml([str(cda_path)], [str(cc08_path), str(gc08_path)], str(index_out), index_xsd)
+    assert orch.generate_aggregated_summary_xml([str(cc08_path), str(gc08_path)], [str(cda_path)], str(summary_out), summary_xsd)
+
+    ns = {"m": "https://www.mhlw.go.jp/stf/seisakunitsuite/bunya/0000161103.html"}
+    tree_i = etree.parse(str(index_out))
+    assert tree_i.xpath("/m:index/m:totalRecordCount/@value", namespaces=ns)[0] == "3"
+
+    tree_s = etree.parse(str(summary_out))
+    assert tree_s.xpath("/m:summary/m:totalSubjectCount/@value", namespaces=ns)[0] == "1"
+    assert tree_s.xpath("/m:summary/m:totalClaimAmount/@value", namespaces=ns)[0] == "4000"


### PR DESCRIPTION
## Summary
- implement aggregation using rule files in orchestrator
- update index and summary rule definitions
- create unit test covering index and summary generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684554d25df88333972056b2eae9c3be