### PR TITLE
Docs: update limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project automates the processing of Japanese "特定健診／特定保健�
 
 ## Key Features
 
-*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8, Shift_JIS) and delimiters, with mandatory column validation.
+*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8, Shift_JIS) and delimiters, with mandatory column validation. Header rows can also be supplied via `column_names` in a profile.
 *   **Rule-Based Transformation:** Maps CSV data to intermediate models using external JSON rule files. (Note: Phase 2 for full rule engine implementation is pending).
 *   **XML Generation:** Creates multiple XML types:
     *   Health Checkup CDA (hc08)
@@ -177,6 +177,5 @@ implemented and validated against their XSD schemas:
 
 ### Known Limitations / TODOs
 
-* CSV files without headers are not yet supported.
 * Several orchestrator calls still pass raw dictionaries to the generators.
 * Command-line options are minimal and may change as development continues.


### PR DESCRIPTION
## Summary
- add note in CSV parser feature bullet about supplying header rows via `column_names`
- remove mention that CSV files without headers are not supported

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452d2f9d308333b9f3b157b1bb61d2