### PR TITLE
Update README headerless CSV note

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project automates the processing of Japanese "特定健診／特定保健�
 
 ## Key Features
 
-*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8, Shift_JIS) and delimiters, with mandatory column validation. Header rows can also be supplied via `column_names` in a profile.
+*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8, Shift_JIS) and delimiters, with mandatory column validation. Header rows can be supplied via `column_names` in a profile, allowing CSVs without headers to be parsed.
 *   **Rule-Based Transformation:** Maps CSV data to intermediate models using external JSON rule files. (Note: Phase 2 for full rule engine implementation is pending).
 *   **XML Generation:** Creates multiple XML types:
     *   Health Checkup CDA (hc08)


### PR DESCRIPTION
## Summary
- clarify headerless CSV support in the key features section
- drop obsolete limitation about headerless CSV

## Testing
- `pytest -q` *(fails: AssertionError in test_index_and_summary_rules_files)*

------
https://chatgpt.com/codex/tasks/task_e_684568d62d248333886d242b4fa87182