### PR TITLE
Refactor orchestrator models and add sample archive test

### DIFF
--- a/src/csv_to_xml_converter/models.py
+++ b/src/csv_to_xml_converter/models.py
@@ -388,4 +388,78 @@ class GuidanceSettlementRecord(IntermediateRecord): # Inherits from Intermediate
         # For now, this simple vars(self) relies on rules directly setting documentIdRootOid etc.
         return data
 
-# Self-test / example usage
+# ---------------------------------------------------------------------------
+# Additional simple dataclasses used by the orchestrator once dictionary based
+# paths were removed.  These models intentionally mirror the minimal fields
+# required by the XML generators.  Rule files can still populate additional
+# attributes, but the orchestrator now deals with strongly typed objects.
+
+@dataclass
+class IndexRecord(IntermediateRecord):
+    """Model for index.xml generation."""
+    interactionType: Optional[str] = None
+    creationTime: Optional[str] = None
+    senderIdRootOid: Optional[str] = None
+    senderIdExtension: Optional[str] = None
+    receiverIdRootOid: Optional[str] = None
+    receiverIdExtension: Optional[str] = None
+    serviceEventType: Optional[str] = None
+    totalRecordCount: Optional[int] = None
+
+    def to_xml_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
+        for f_name in [
+            "interactionType",
+            "creationTime",
+            "senderIdRootOid",
+            "senderIdExtension",
+            "receiverIdRootOid",
+            "receiverIdExtension",
+            "serviceEventType",
+            "totalRecordCount",
+        ]:
+            v = getattr(self, f_name)
+            if v is not None:
+                d[f_name] = v
+        return d
+
+
+@dataclass
+class SummaryRecord(IntermediateRecord):
+    """Model for summary.xml generation."""
+
+    serviceEventTypeCode: Optional[str] = None
+    serviceEventTypeCodeSystem: Optional[str] = None
+    serviceEventTypeDisplayName: Optional[str] = None
+    totalSubjectCount_value: Optional[int] = None
+    totalCostAmountValue: Optional[int] = None
+    totalCostAmount_currency: str = "JPY"
+    totalPaymentAmountValue: Optional[int] = None
+    totalPaymentAmount_currency: str = "JPY"
+    totalClaimAmountValue: Optional[int] = None
+    totalClaimAmount_currency: str = "JPY"
+    totalPaymentByOtherProgramValue: Optional[int] = None
+    totalPaymentByOtherProgram_currency: str = "JPY"
+
+    def to_xml_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {}
+        for f_name in [
+            "serviceEventTypeCode",
+            "serviceEventTypeCodeSystem",
+            "serviceEventTypeDisplayName",
+            "totalSubjectCount_value",
+            "totalCostAmountValue",
+            "totalCostAmount_currency",
+            "totalPaymentAmountValue",
+            "totalPaymentAmount_currency",
+            "totalClaimAmountValue",
+            "totalClaimAmount_currency",
+            "totalPaymentByOtherProgramValue",
+            "totalPaymentByOtherProgram_currency",
+        ]:
+            v = getattr(self, f_name)
+            if v is not None:
+                d[f_name] = v
+        return d
+
+

--- a/src/csv_to_xml_converter/xml_generator/__init__.py
+++ b/src/csv_to_xml_converter/xml_generator/__init__.py
@@ -139,26 +139,26 @@ def _create_mo_element(parent_el: etree._Element, el_name: str, item_data: Any, 
     return None
 
 # --- Fully Restored XML Generators ---
-def generate_index_xml(transformed_data: Dict[str, Any]) -> str:
+def generate_index_xml(transformed_data: Dict[str, Any] | Any) -> str:
     schema_loc_val = f"{MHLW_NS_URL} ix08_V08.xsd"
     root = etree.Element("index", nsmap=NSMAP_MHLW_DEFAULT)
     root.set(f"{{{XSI_NS}}}schemaLocation", schema_loc_val)
-    etree.SubElement(root, "interactionType").set("code", _str_or_default(transformed_data.get("interactionType"), "1"))
-    etree.SubElement(root, "creationTime").set("value", _str_or_default(transformed_data.get("creationTime")))
+    etree.SubElement(root, "interactionType").set("code", _str_or_default(_get_value(transformed_data, "interactionType"), "1"))
+    etree.SubElement(root, "creationTime").set("value", _str_or_default(_get_value(transformed_data, "creationTime")))
     sender_el = etree.SubElement(root, "sender")
     _create_ii_element(sender_el, "id", transformed_data, "senderId")
     receiver_el = etree.SubElement(root, "receiver")
     _create_ii_element(receiver_el, "id", transformed_data, "receiverId")
-    etree.SubElement(root, "serviceEventType").set("code", _str_or_default(transformed_data.get("serviceEventType"), "1"))
-    etree.SubElement(root, "totalRecordCount").set("value", _str_or_default(transformed_data.get("totalRecordCount"), "0"))
+    etree.SubElement(root, "serviceEventType").set("code", _str_or_default(_get_value(transformed_data, "serviceEventType"), "1"))
+    etree.SubElement(root, "totalRecordCount").set("value", _str_or_default(_get_value(transformed_data, "totalRecordCount"), "0"))
     return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="utf-8").decode("utf-8")
 
-def generate_summary_xml(transformed_data: Dict[str, Any]) -> str:
+def generate_summary_xml(transformed_data: Dict[str, Any] | Any) -> str:
     schema_loc_val = f"{MHLW_NS_URL} su08_V08.xsd"
     root = etree.Element("summary", nsmap=NSMAP_MHLW_DEFAULT)
     root.set(f"{{{XSI_NS}}}schemaLocation", schema_loc_val)
 
-    set_code = transformed_data.get("serviceEventTypeCode")
+    set_code = _get_value(transformed_data, "serviceEventTypeCode")
     if set_code is not None:
         set_el = etree.SubElement(root, "serviceEventType")
         set_el.set("code", _str_or_default(set_code))
@@ -167,7 +167,7 @@ def generate_summary_xml(transformed_data: Dict[str, Any]) -> str:
     _create_mo_element(root, "totalCostAmount", transformed_data, "totalCostAmount", currency_key_suffix="_currency")
     _create_mo_element(root, "totalPaymentAmount", transformed_data, "totalPaymentAmount", currency_key_suffix="_currency")
     _create_mo_element(root, "totalClaimAmount", transformed_data, "totalClaimAmount", currency_key_suffix="_currency")
-    if transformed_data.get("totalPaymentByOtherProgramValue") is not None:
+    if _get_value(transformed_data, "totalPaymentByOtherProgramValue") is not None:
          _create_mo_element(root, "totalPaymentByOtherProgram", transformed_data, "totalPaymentByOtherProgram", currency_key_suffix="_currency")
     return etree.tostring(root, pretty_print=True, xml_declaration=True, encoding="utf-8").decode("utf-8")
 

--- a/tests/test_orchestrator_real_sample.py
+++ b/tests/test_orchestrator_real_sample.py
@@ -1,0 +1,8 @@
+import os
+from csv_to_xml_converter.orchestrator import Orchestrator
+
+
+def test_verify_real_sample_archive():
+    orch = Orchestrator({})
+    sample_zip = os.path.join('data', '5521111111_00280081_202405271_1.zip')
+    assert not orch.verify_archive_contents(sample_zip)


### PR DESCRIPTION
## Summary
- add typed `IndexRecord` and `SummaryRecord` models
- update `generate_aggregated_*` functions to work with the new dataclasses
- allow XML generators to accept dataclass objects
- include a regression test using the provided sample archive

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684657a75f288333b4e7104c656d1b81