### PR TITLE
Refactor XML utils

### DIFF
--- a/src/csv_to_xml_converter/xml_generator/__init__.py
+++ b/src/csv_to_xml_converter/xml_generator/__init__.py
@@ -16,6 +16,7 @@ from . import xml_parsing_utils
 from .xml_parsing_utils import (
     get_claim_amount_from_cc08,
     get_claim_amount_from_gc08,
+    get_claim_amount,
     get_subject_count_from_cda,
 )
 
@@ -28,6 +29,7 @@ __all__ = [
     "generate_guidance_settlement_xml",
     "get_claim_amount_from_cc08",
     "get_claim_amount_from_gc08",
+    "get_claim_amount",
     "get_subject_count_from_cda",
 ]
 

--- a/tests/test_xml_parsing_utils.py
+++ b/tests/test_xml_parsing_utils.py
@@ -2,6 +2,7 @@ import os
 from csv_to_xml_converter.xml_generator.xml_parsing_utils import (
     get_claim_amount_from_cc08,
     get_claim_amount_from_gc08,
+    get_claim_amount,
     get_subject_count_from_cda,
 )
 
@@ -31,5 +32,8 @@ def test_xml_parsing_utils(tmp_path):
 
     assert get_claim_amount_from_cc08(str(cc08_path)) == 12345.67
     assert get_claim_amount_from_gc08(str(gc08_path)) == 5000.0
+    assert get_claim_amount(str(cc08_path)) == 12345.67
+    assert get_claim_amount(str(gc08_path)) == 5000.0
+    assert get_claim_amount(str(cda_path)) is None
     assert get_subject_count_from_cda(str(cda_path)) == 1
     assert get_subject_count_from_cda(str(cc08_path)) == 0


### PR DESCRIPTION
## Summary
- add new `get_claim_amount` helper that automatically detects CC08 or GC08 claim XMLs
- expose `get_claim_amount` in `xml_generator`
- test the new helper

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a04fb2c48333ab2be9a0334f1aac