### PR TITLE
Refactor config loader to use pathlib

### DIFF
--- a/src/csv_to_xml_converter/config/__init__.py
+++ b/src/csv_to_xml_converter/config/__init__.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import json
 import os
+from pathlib import Path
+from typing import Union
 
-DEFAULT_CONFIG_PATH = "config_rules/config.json"
+DEFAULT_CONFIG_PATH = Path("config_rules/config.json")
 
-def load_config(config_path: str = DEFAULT_CONFIG_PATH) -> dict:
+def load_config(config_path: Union[str, os.PathLike[str], Path] = DEFAULT_CONFIG_PATH) -> dict:
     """
     Loads the JSON configuration file.
 
@@ -18,21 +22,24 @@ def load_config(config_path: str = DEFAULT_CONFIG_PATH) -> dict:
         ValueError: If the config file is not valid JSON or top-level is not a dict.
         Exception: For other unexpected errors during file loading.
     """
-    if not os.path.exists(config_path):
+    config_path = Path(config_path)
+
+    if not config_path.exists():
         # Try to construct path relative to this file's directory if a relative path is given
-        # This helps when the script is run from different working directories.
-        if not os.path.isabs(config_path):
-            current_dir = os.path.dirname(os.path.abspath(__file__))
-            rel_path = os.path.join(current_dir, "..", "..", "..", config_path) # Adjust based on actual structure if needed
-            if os.path.exists(rel_path):
+        if not config_path.is_absolute():
+            current_dir = Path(__file__).resolve().parent
+            rel_path = current_dir / ".." / ".." / ".." / config_path
+            if rel_path.exists():
                 config_path = rel_path
             else:
-                 raise FileNotFoundError(f"Configuration file not found at {config_path} or {rel_path}")
+                raise FileNotFoundError(
+                    f"Configuration file not found at {config_path} or {rel_path}"
+                )
         else:
             raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
     try:
-        with open(config_path, 'r', encoding='utf-8') as f: # Specify encoding
+        with config_path.open("r", encoding="utf-8") as f:
             config = json.load(f)
     except json.JSONDecodeError as e:
         raise ValueError(f"Error decoding JSON from config file {config_path}: {e}")


### PR DESCRIPTION
## Summary
- use `pathlib.Path` in the config loader

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68692af017b8833388e50c0fa38dc40f