### PR TITLE
Fix validator imports and formatting

### DIFF
--- a/src/csv_to_xml_converter/validator/__init__.py
+++ b/src/csv_to_xml_converter/validator/__init__.py
@@ -3,18 +3,25 @@
 XML Validator module using lxml.etree.XMLSchema.
 """
 import logging
+import os
+
+from typing import List, Tuple
+from lxml import etree
+
 logger = logging.getLogger(__name__)
 
-from lxml import etree
-from typing import Tuple, List, Optional
-import os
-import sys
 
 class XMLValidationError(Exception):
-    """Custom exception for XML validation specific issues like XSD loading failure."""
+    """Custom exception for XML validation specific issues.
+
+    These include failures such as errors while loading an XSD file.
+    """
     pass
 
-def validate_xml(xml_string: str, xsd_file_path: str) -> Tuple[bool, List[str]]:
+
+def validate_xml(
+    xml_string: str, xsd_file_path: str
+) -> Tuple[bool, List[str]]:
     error_messages = []
     try:
         if not os.path.exists(xsd_file_path):
@@ -25,12 +32,17 @@ def validate_xml(xml_string: str, xsd_file_path: str) -> Tuple[bool, List[str]]:
         is_valid = xmlschema.validate(xml_doc_tree)
         if not is_valid:
             for error in xmlschema.error_log:
-                error_messages.append(f"Validation Error: Line {error.line}, Column {error.column} - {error.message} (Domain: {error.domain_name}, Type: {error.type_name})")
+                error_messages.append(
+                    "Validation Error: Line "
+                    f"{error.line}, Column {error.column} - {error.message} "
+                    f"(Domain: {error.domain_name}, Type: {error.type_name})"
+                )
         return is_valid, error_messages
     except etree.XMLSchemaParseError as e:
-        raise XMLValidationError(f"Failed to parse XSD schema {xsd_file_path}: {e}")
+        raise XMLValidationError(
+            f"Failed to parse XSD schema {xsd_file_path}: {e}"
+        )
     except etree.XMLSyntaxError as e:
         return False, [f"Invalid XML syntax: {e}"]
     except Exception as e:
         return False, [f"An unexpected error occurred during validation: {e}"]
-


### PR DESCRIPTION
## Summary
- cleanup import order and remove unused modules in validator
- wrap long strings and function definition
- add spacing around top-level definitions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694f7ff75c8333839229c0296633df