### PR TITLE
Add docstring to GUI module

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -1,3 +1,9 @@
+"""Tkinter-based GUI for invoking the CLI converter.
+
+This module defines a simple graphical interface around the command-line
+utilities so users can run conversions without typing commands.
+"""
+
 import tkinter as tk
 from tkinter import filedialog, messagebox
 


### PR DESCRIPTION
## Summary
- document src/gui.py with a short module docstring about the Tkinter GUI wrapper around the CLI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cca7803c83338f225409deab5eac