### PR TITLE
Fix xml_generator __all__ export

### DIFF
--- a/src/csv_to_xml_converter/xml_generator/__init__.py
+++ b/src/csv_to_xml_converter/xml_generator/__init__.py
@@ -33,6 +33,7 @@ __all__ = [
     "get_claim_amount_from_gc08",
     "get_claim_amount",
     "get_subject_count_from_cda",
+    "xml_parsing_utils",
 ]
 
 # Ensure submodule is exported for package consumers

--- a/tests/test_xml_generator_exports.py
+++ b/tests/test_xml_generator_exports.py
@@ -1,0 +1,5 @@
+from csv_to_xml_converter.xml_generator import xml_parsing_utils
+
+
+def test_xml_parsing_utils_exported():
+    assert hasattr(xml_parsing_utils, 'get_claim_amount')


### PR DESCRIPTION
## Summary
- export `xml_parsing_utils` from `xml_generator` via `__all__`
- add test to verify that the submodule is accessible from the package

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869cef5abd88333ae3de5c5ff056180