### PR TITLE
Add shared XML parser

### DIFF
--- a/src/csv_to_xml_converter/utils/__init__.py
+++ b/src/csv_to_xml_converter/utils/__init__.py
@@ -1,0 +1,26 @@
+"""Utility helpers for the CSVXLM project."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from lxml import etree
+
+logger = logging.getLogger(__name__)
+
+
+def parse_xml(path: str) -> Optional[etree._ElementTree]:
+    """Return an ``ElementTree`` for ``path`` or ``None`` on error."""
+    try:
+        return etree.parse(path)
+    except etree.XMLSyntaxError as exc:
+        logger.error("XMLSyntaxError parsing %s: %s", path, exc)
+    except OSError as exc:
+        logger.error("Error reading XML %s: %s", path, exc)
+    except Exception as exc:  # pragma: no cover - unexpected errors
+        logger.error("Unexpected error parsing %s: %s", path, exc)
+    return None
+
+
+__all__ = ["parse_xml"]

--- a/tests/test_xml_parsing_utils.py
+++ b/tests/test_xml_parsing_utils.py
@@ -5,6 +5,7 @@ from csv_to_xml_converter.xml_generator.xml_parsing_utils import (
     get_claim_amount,
     get_subject_count_from_cda,
 )
+from csv_to_xml_converter.utils import parse_xml
 
 
 def test_xml_parsing_utils(tmp_path):
@@ -37,3 +38,8 @@ def test_xml_parsing_utils(tmp_path):
     assert get_claim_amount(str(cda_path)) is None
     assert get_subject_count_from_cda(str(cda_path)) == 1
     assert get_subject_count_from_cda(str(cc08_path)) == 0
+
+    # verify parse_xml helper returns None on malformed XML
+    bad_xml = tmp_path / "bad.xml"
+    bad_xml.write_text("<bad>", encoding="utf-8")
+    assert parse_xml(str(bad_xml)) is None


### PR DESCRIPTION
## Summary
- add reusable `parse_xml` helper under `utils`
- refactor XML parsing utils to use the new helper
- extend tests for the new function

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3168ac8c8333a6d0fe0651ed6de5