### PR TITLE
Export key rule engine helpers

### DIFF
--- a/src/csv_to_xml_converter/rule_engine/__init__.py
+++ b/src/csv_to_xml_converter/rule_engine/__init__.py
@@ -9,6 +9,17 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__) # Moved logger definition up
 
+__all__ = [
+    "load_rules",
+    "apply_rules",
+    "RuleApplicationError",
+    "to_integer",
+    "to_date_yyyymmdd",
+    "to_boolean",
+    "round_number",
+    "calculate_bmi",
+]
+
 def _set_nested_attr(target_obj: Any, attr_path: str, value: Any):
     logger.debug(f"Setting nested attr: path='{attr_path}', value='{value}' on obj of type {type(target_obj)}")
     parts = attr_path.split('.')


### PR DESCRIPTION
## Summary
- expose common rule engine helpers via `__all__`
- keep imports backwards compatible

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4645541c8333b049572bfd67f839