### PR TITLE
Remove redundant export line

### DIFF
--- a/src/csv_to_xml_converter/xml_generator/__init__.py
+++ b/src/csv_to_xml_converter/xml_generator/__init__.py
@@ -37,7 +37,6 @@ __all__ = [
 ]
 
 # Ensure submodule is exported for package consumers
-xml_parsing_utils
 
 
 # --- Namespaces (Consistent with successful prior states) ---


### PR DESCRIPTION
## Summary
- drop unused `xml_parsing_utils` module export line
- keep xml_parsing_utils import and __all__ entry

## Testing
- `pytest tests/test_xml_generator_exports.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a45558c8883339525af64cab29f36