### PR TITLE
Add log level option to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,11 @@ The application is configured to look for XSDs in these specific locations. The 
     Use the interface to select the configuration JSON and specify the CSV profile.
 3.  Alternatively, run the CLI directly:
     ```bash
-    python src/main.py [-c CONFIG] [-p PROFILE]
+    python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
     ```
     * `CONFIG` – path to a configuration JSON file (defaults to `config_rules/config.json`)
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
+    * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/src/main.py
+++ b/src/main.py
@@ -116,6 +116,11 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
             "Used to parse the input CSV files."
         ),
     )
+    parser.add_argument(
+        "--log-level",
+        choices=["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"],
+        help="Override logging level from the configuration file.",
+    )
     return parser.parse_args(args)
 
 
@@ -131,6 +136,8 @@ def main(cli_args=None):
     except Exception as e:
         logging.error("Error loading config: %s", e)
         app_config = {"logging": {}}
+    if cli.log_level:
+        app_config.setdefault("logging", {})["log_level"] = cli.log_level
     app_config["_config_file_path_"] = config_path
     main_logger = setup_logger(config=app_config)
     main_logger.info("Application starting - Grouped CDA Test Run...")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+# Allow importing main from src directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from main import parse_args
+
+
+def test_parse_args_log_level():
+    args = parse_args(["--log-level", "DEBUG"])
+    assert args.log_level == "DEBUG"
+
+def test_parse_args_log_level_default():
+    args = parse_args([])
+    assert args.log_level is None


### PR DESCRIPTION
## Summary
- allow overriding log level via `--log-level` in CLI
- document the new option in `README.md`
- add unit tests for `parse_args` to ensure the option is parsed correctly

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a57ae3b348333a41ede22e279a596