### PR TITLE
Add Japanese usage guide

### DIFF
--- a/README_JA.md
+++ b/README_JA.md
@@ -1,0 +1,56 @@
+# CSVからMHLW XMLへの変換・パッケージツール (CSVXLM)
+
+## 概要
+
+本プロジェクトは「特定健診／特定保健指導」データのCSVを入力とし、設定ファイルに基づきXMLへ変換、ZIP形式でパッケージ化するツールです。
+
+## ディレクトリ構成
+
+- `src/` メインのPythonコード
+- `config_rules/` 各種設定JSONおよびルールファイル
+- `data/` 入力CSV、生成されたXML、ZIPアーカイブ、XSDスキーマを格納
+- `tests/` 単体テスト
+
+## 環境構築
+
+Python 3.10以上で動作します。依存パッケージをインストールするには以下を実行してください。
+
+```bash
+pip install -r requirements.txt
+```
+
+XSDファイルは`data/xsd_schemas`および`data/xsd_schemas_official`以下に配置してください。
+
+## 使い方
+
+### GUI
+
+```bash
+python src/gui.py
+```
+
+画面から設定JSONとCSVプロファイルを指定して変換を実行します。
+
+### CLI
+
+```bash
+python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
+```
+
+- `CONFIG` : 設定JSONへのパス (デフォルト: `config_rules/config.json`)
+- `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
+- `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
+
+出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
+
+## テスト実行
+
+依存パッケージをインストール後、プロジェクトルートで次を実行してテストを行います。
+
+```bash
+pytest -q
+```
+
+## ライセンス
+
+このプロジェクトはMITライセンスです。


### PR DESCRIPTION
## Summary
- add `README_JA.md` with instructions in Japanese

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a646e75148333b758fb6455a8bbff