### PR TITLE
Add packaging and CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,23 @@ original Shift_JIS file `CSVからXML変換詳細手順説明.txt`.
 
 ## Environment Setup
 
-The project targets **Python 3.10+**.  Install the required
-dependencies with:
+The project targets **Python 3.10+**.
+
+## Installation
+
+Install the project and its dependencies with:
+
+```bash
+pip install .
+```
+
+This installs the `lxml` library and registers the ``csvxlm`` command
+line entry point.  If you prefer, you can still install the
+dependencies directly using:
 
 ```bash
 pip install -r requirements.txt
 ```
-
-This installs the `lxml` library which is required for XML generation
-and validation. The CLI uses Python's built-in `argparse` so no
-additional packages are required. If you are running Python 3.6, also
-install the `dataclasses` backport.
 
 ## XSD File Setup (Crucial for Operation)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "csvxlm"
+version = "0.1.0"
+description = "CSV to MHLW XML conversion and packaging tool"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "CSVXLM Authors"}]
+dependencies = [
+    "lxml",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["csv_to_xml_converter", "sample_test_mode"]
+py-modules = ["main", "gui"]
+
+[project.scripts]
+csvxlm = "csv_to_xml_converter.main:main"

--- a/src/csv_to_xml_converter/main.py
+++ b/src/csv_to_xml_converter/main.py
@@ -1,0 +1,9 @@
+"""CLI entry point wrapper for the ``csvxlm`` console script."""
+
+from main import main as _main
+
+
+def main() -> None:
+    """Run the application's main CLI."""
+    _main()
+


### PR DESCRIPTION
## Summary
- create `pyproject.toml` with metadata, dependency on `lxml` and console script
- wrap CLI entry point in `csv_to_xml_converter.main`
- document package installation and new `csvxlm` command

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687395fa880c833381229caa6f22b43f