### PR TITLE
Add missing file tests and raise validator error

### DIFF
--- a/src/csv_to_xml_converter/validator/__init__.py
+++ b/src/csv_to_xml_converter/validator/__init__.py
@@ -23,9 +23,9 @@ def validate_xml(
     xml_string: str, xsd_file_path: str
 ) -> Tuple[bool, List[str]]:
     error_messages = []
+    if not os.path.exists(xsd_file_path):
+        raise XMLValidationError(f"XSD file not found: {xsd_file_path}")
     try:
-        if not os.path.exists(xsd_file_path):
-            raise XMLValidationError(f"XSD file not found: {xsd_file_path}")
         xsd_doc = etree.parse(xsd_file_path)
         xmlschema = etree.XMLSchema(xsd_doc)
         xml_doc_tree = etree.fromstring(xml_string.encode("utf-8"))

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -143,3 +143,9 @@ def test_csv_parser(tmp_path):
     bom_csv.write_text("name,age\nAmy,22", encoding="utf-8-sig")
     records_bom = parse_csv(str(bom_csv), encoding="shift_jis")
     assert records_bom[0] == {"name": "Amy", "age": "22"}
+
+
+def test_parse_csv_from_profile_file_not_found():
+    profile = {"source": "does_not_exist.csv"}
+    with pytest.raises(FileNotFoundError):
+        parse_csv_from_profile(profile)

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,6 +1,7 @@
 import os
+import pytest
 from lxml import etree
-from csv_to_xml_converter.validator import validate_xml
+from csv_to_xml_converter.validator import validate_xml, XMLValidationError
 from csv_to_xml_converter.xml_generator import (
     MHLW_NS_URL as XML_GEN_MHLW_NS_URL,
     XSI_NS as XML_GEN_XSI_NS,
@@ -41,3 +42,11 @@ def test_validate_xml(tmp_path):
     invalid_struct_xml = etree.tostring(root, xml_declaration=True, encoding="utf-8").decode("utf-8")
     is_valid, errors = validate_xml(invalid_struct_xml, xsd_path)
     assert not is_valid
+
+
+def test_validate_xml_missing_xsd(tmp_path):
+    """validate_xml should raise XMLValidationError when XSD is absent."""
+    xml = "<root/>"
+    missing_xsd = tmp_path / "missing.xsd"
+    with pytest.raises(XMLValidationError):
+        validate_xml(xml, str(missing_xsd))


### PR DESCRIPTION
## Summary
- ensure `validate_xml` throws `XMLValidationError` when the schema path doesn't exist
- extend validator tests to cover missing XSDs
- add regression test for `parse_csv_from_profile` with an invalid path

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687396f7a5488333830bea3e874c4bee