### PR TITLE
Add module entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ The application is configured to look for XSDs in these specific locations. The 
     ```bash
     python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
     ```
+    Or using the module form:
+    ```bash
+    python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
+    ```
     * `CONFIG` – path to a configuration JSON file (defaults to `config_rules/config.json`)
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration

--- a/README_JA.md
+++ b/README_JA.md
@@ -36,6 +36,10 @@ python src/gui.py
 ```bash
 python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 ```
+モジュール形式で実行する場合:
+```bash
+python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
+```
 
 - `CONFIG` : 設定JSONへのパス (デフォルト: `config_rules/config.json`)
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)

--- a/src/csv_to_xml_converter/__main__.py
+++ b/src/csv_to_xml_converter/__main__.py
@@ -1,0 +1,4 @@
+from main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow running the package via `python -m csv_to_xml_converter`
- document the new invocation in English and Japanese READMEs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68743aea198883339db61474e678d101