### PR TITLE
Add header mapping option to CSV parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ original Shift_JIS file `CSVからXML変換詳細手順説明.txt`.
 
 ## Key Features
 
-*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8/Shift_JIS) and automatic detection of UTF-8 BOM files. Header rows can be supplied via `column_names` when calling `parse_csv_from_profile`, allowing CSVs without headers to be parsed.
+*   **CSV Parsing:** Flexible CSV reader supporting various encodings (UTF-8/Shift_JIS) and automatic detection of UTF-8 BOM files. Header rows can be supplied via `column_names` when calling `parse_csv_from_profile`, allowing CSVs without headers to be parsed. Headers may also be renamed using the optional `header_mapping` parameter.
 *   **Rule-Based Transformation:** Maps CSV data to intermediate models using external JSON rule files. The rule engine now supports dataclass targets, rounding of numeric values, and standardized handling of missing data.
 *   **XML Generation:** Creates multiple XML types:
     *   Health Checkup CDA (hc08)

--- a/tests/test_csv_parser.py
+++ b/tests/test_csv_parser.py
@@ -149,3 +149,23 @@ def test_parse_csv_from_profile_file_not_found():
     profile = {"source": "does_not_exist.csv"}
     with pytest.raises(FileNotFoundError):
         parse_csv_from_profile(profile)
+
+
+def test_header_mapping(tmp_path):
+    csv_path = tmp_path / "hm.csv"
+    csv_path.write_text("Name,Age\nBob,20", encoding="utf-8")
+    profile = {"source": str(csv_path)}
+    mapping = {"Name": "name", "Age": "age"}
+    records = parse_csv_from_profile(profile, header_mapping=mapping)
+    assert records == [{"name": "Bob", "age": "20"}]
+
+    csv_no_header = tmp_path / "hm_no_header.csv"
+    csv_no_header.write_text("1,2", encoding="utf-8")
+    profile_no_header = {
+        "source": str(csv_no_header),
+        "has_header": False,
+        "column_names": ["ColA", "ColB"],
+    }
+    mapping2 = {"ColA": "a", "ColB": "b"}
+    recs = parse_csv_from_profile(profile_no_header, header_mapping=mapping2)
+    assert recs[0] == {"a": "1", "b": "2"}


### PR DESCRIPTION
## Summary
- add optional `header_mapping` to parse_csv and parse_csv_from_profile
- rename headers during parsing if mapping is provided
- test header mapping behaviour
- document the new argument in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875e10d9f98833391b8a4b4dfcf1a72