### PR TITLE
Enable custom sample test size

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,16 +104,16 @@ The application is configured to look for XSDs in these specific locations. The 
     * `CONFIG` – path to a configuration JSON file (defaults to `config_rules/config.json`)
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
-    * `--sample-test` – process two CSV files from each test data folder to ensure the pipeline works without converting the entire datasets
+    * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`
     or `false` to control the destinations.
 6.  Sample test data is located in the following folders:
     `3610123279`, `3610123675`, `3610123808`, and `40歳未満健診CSV`. Running
-    `python src/main.py --sample-test` converts the first two CSV files from each of these
-    directories to XML. This keeps the tests lightweight and avoids processing
-    the full datasets.
+    `python src/main.py --sample-test --sample-num-files 1` converts the first CSV file from each of these
+    directories to XML. Adjust the number with `--sample-num-files` as needed. This keeps the tests lightweight
+    and avoids processing the full datasets.
 
 ## Running Tests
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -44,10 +44,10 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `CONFIG` : 設定JSONへのパス (デフォルト: `config_rules/config.json`)
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
-- `--sample-test` : テスト用フォルダから各2件のみ処理して動作確認を行います
+- `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
-テスト用データは `3610123279`, `3610123675`, `3610123808`, `40歳未満健診CSV` の各フォルダにあります。 `--sample-test` オプションを指定すると、これらのフォルダから先頭2ファイルずつのみ処理し、動作を確認できます。大量データ全体を変換せず軽量にテストできるため推奨です。
+テスト用データは `3610123279`, `3610123675`, `3610123808`, `40歳未満健診CSV` の各フォルダにあります。 `--sample-test` オプションを指定すると、これらのフォルダから指定した件数（`--sample-num-files`）のCSVのみ処理し、動作を確認できます。大量データ全体を変換せず軽量にテストできるため推奨です。
 
 ## テスト実行
 

--- a/src/main.py
+++ b/src/main.py
@@ -126,6 +126,18 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="Run sample data conversion test using bundled folders.",
     )
+    parser.add_argument(
+        "--sample-num-files",
+        type=int,
+        default=2,
+        metavar="N",
+        help="Number of CSV files to convert from each folder when using --sample-test.",
+    )
+    parser.add_argument(
+        "--sample-only",
+        action="store_true",
+        help="When used with --sample-test, skip the normal conversion workflow.",
+    )
     return parser.parse_args(args)
 
 
@@ -170,7 +182,14 @@ def main(cli_args=None):
             "40歳未満健診CSV",
         ]
         out_dir = app_config.get("paths", {}).get("output_xmls", "data/output_xmls")
-        convert_first_csvs(test_dirs, os.path.join(out_dir, "sample_test"), num_files=2)
+        convert_first_csvs(
+            test_dirs,
+            os.path.join(out_dir, "sample_test"),
+            num_files=cli.sample_num_files,
+        )
+        if cli.sample_only:
+            main_logger.info("Sample test complete; exiting as --sample-only was provided.")
+            return
 
     # Initialize lists for collecting generated XML file paths
     all_data_xml_files = []


### PR DESCRIPTION
## Summary
- add `--sample-num-files` and `--sample-only` options to CLI
- update README instructions for new options
- document options in Japanese README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python src/main.py --sample-test --sample-num-files 1 --sample-only --log-level INFO`

------
https://chatgpt.com/codex/tasks/task_e_68762f2c40d48333a6489493cd3d94be