### PR TITLE
Add Windows batch script for GUI startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ The application is configured to look for XSDs in these specific locations. The 
     python src/gui.py
     ```
     Use the interface to select the configuration JSON and specify the CSV profile.
+    On Windows systems you can also launch the GUI by executing
+    `run_gui.bat` in the project root.
 3.  Alternatively, run the CLI directly:
     ```bash
     python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]

--- a/README_JA.md
+++ b/README_JA.md
@@ -30,6 +30,7 @@ python src/gui.py
 ```
 
 画面から設定JSONとCSVプロファイルを指定して変換を実行します。
+Windows環境ではプロジェクトルートの `run_gui.bat` を実行することで同じGUIが起動します。
 
 ### CLI
 

--- a/run_gui.bat
+++ b/run_gui.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d "%~dp0"
+python src\gui.py %*
+pause


### PR DESCRIPTION
## Summary
- add `run_gui.bat` for launching the GUI on Windows
- document batch script usage in README and README_JA

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876e84f4ee4833389bae59eaf54512c