### PR TITLE
Add CSV to JSON conversion utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ The application is configured to look for XSDs in these specific locations. The 
     ```
     Use the interface to select the configuration JSON and specify the CSV profile.
     On Windows systems you can also launch the GUI by executing
-    `run_gui.bat` in the project root.
+    `run_gui.bat` in the project root. A "CSV→JSON変換" button is provided to
+    export a single CSV to JSON using the chosen profile.
 3.  Alternatively, run the CLI directly:
     ```bash
     python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
@@ -107,6 +108,7 @@ The application is configured to look for XSDs in these specific locations. The 
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
+    * `--csv-to-json CSV` – parse the specified CSV and write the records to a JSON file, then exit.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/README_JA.md
+++ b/README_JA.md
@@ -31,6 +31,7 @@ python src/gui.py
 
 画面から設定JSONとCSVプロファイルを指定して変換を実行します。
 Windows環境ではプロジェクトルートの `run_gui.bat` を実行することで同じGUIが起動します。
+GUIにはCSVをJSONに変換する「CSV→JSON変換」ボタンも用意されています。
 
 ### CLI
 
@@ -46,6 +47,7 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
+- `--csv-to-json CSV` : 指定したCSVを解析しJSONファイルとして保存して終了します。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
 テスト用にはリポジトリ直下に `TEST.csv` を同梱しています。以前の README で案内していた

--- a/src/csv_to_xml_converter/utils/__init__.py
+++ b/src/csv_to_xml_converter/utils/__init__.py
@@ -8,6 +8,8 @@ from typing import Optional, Union
 
 from lxml import etree
 
+from .csv_to_json import convert_csv_to_json
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,4 +32,4 @@ def parse_xml(path: Union[str, PathLike[str]]) -> Optional[etree._ElementTree]:
     return None
 
 
-__all__ = ["parse_xml"]
+__all__ = ["parse_xml", "convert_csv_to_json"]

--- a/src/csv_to_xml_converter/utils/csv_to_json.py
+++ b/src/csv_to_xml_converter/utils/csv_to_json.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Helper to convert a CSV file to JSON using configured profiles."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from ..config import load_config, DEFAULT_CONFIG_PATH
+from ..csv_parser import parse_csv_from_profile
+
+logger = logging.getLogger(__name__)
+
+# Allow tests or callers to override the configuration file used
+DEFAULT_CONFIG_FILE = str(DEFAULT_CONFIG_PATH)
+
+
+def _build_profile(config: dict, profile_name: str, csv_path: str) -> dict:
+    """Return a profile dictionary for ``parse_csv_from_profile``."""
+    profiles = config.get("csv_profiles", {})
+    profile = profiles.get(profile_name)
+    if profile is None:
+        profile = profiles.get("default", {})
+        logger.warning("Profile '%s' not found. Using 'default'.", profile_name)
+    # Map config keys to parse_csv_from_profile format
+    prof = profile.copy()
+    if "header" in prof:
+        prof["has_header"] = prof.pop("header")
+    if "columns" in prof:
+        prof["column_names"] = prof.pop("columns")
+    prof["source"] = csv_path
+    return prof
+
+
+def convert_csv_to_json(csv_path: str, profile_name: str) -> list[dict]:
+    """Parse ``csv_path`` using ``profile_name`` and write JSON next to the CSV."""
+    config = load_config(DEFAULT_CONFIG_FILE)
+    profile = _build_profile(config, profile_name, csv_path)
+    records = parse_csv_from_profile(profile)
+
+    out_path = Path(csv_path).with_suffix(".json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(records, f, ensure_ascii=False, indent=2)
+    logger.info("Wrote %d records to %s", len(records), out_path)
+    return records
+
+
+__all__ = ["convert_csv_to_json"]

--- a/src/gui.py
+++ b/src/gui.py
@@ -34,6 +34,9 @@ class Application(tk.Tk):
         tk.Button(self, text="Run Conversion", command=self._run_conversion).grid(
             row=2, column=0, columnspan=3, pady=10
         )
+        tk.Button(self, text="CSV→JSON変換", command=self._run_csv_to_json).grid(
+            row=3, column=0, columnspan=3, pady=5
+        )
 
     def _browse_config(self):
         file_path = filedialog.askopenfilename(title="Select config file", filetypes=[("JSON", "*.json"), ("All", "*.*")])
@@ -47,6 +50,20 @@ class Application(tk.Tk):
         try:
             cli_main(["--config", config, "--profile", profile])
             messagebox.showinfo("Success", "Conversion completed successfully.")
+        except Exception as exc:
+            messagebox.showerror("Error", f"An error occurred:\n{exc}")
+
+    def _run_csv_to_json(self):
+        csv_path = filedialog.askopenfilename(
+            title="Select CSV file", filetypes=[("CSV", "*.csv"), ("All", "*.*")]
+        )
+        if not csv_path:
+            return
+        config = self.config_entry.get().strip()
+        profile = self.profile_entry.get().strip()
+        try:
+            cli_main(["--config", config, "--profile", profile, "--csv-to-json", csv_path])
+            messagebox.showinfo("Success", "JSON file written next to CSV.")
         except Exception as exc:
             messagebox.showerror("Error", f"An error occurred:\n{exc}")
 

--- a/src/main.py
+++ b/src/main.py
@@ -138,6 +138,11 @@ def parse_args(args: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help="When used with --sample-test, skip the normal conversion workflow.",
     )
+    parser.add_argument(
+        "--csv-to-json",
+        metavar="CSV",
+        help="Parse CSV with the selected profile and output JSON, then exit.",
+    )
     return parser.parse_args(args)
 
 
@@ -158,6 +163,12 @@ def main(cli_args=None):
     app_config["_config_file_path_"] = config_path
     main_logger = setup_logger(config=app_config)
     main_logger.info("Application starting - Grouped CDA Test Run...")
+
+    if cli.csv_to_json:
+        from csv_to_xml_converter.utils import csv_to_json as c2j
+        c2j.DEFAULT_CONFIG_FILE = config_path
+        c2j.convert_csv_to_json(cli.csv_to_json, cli.profile)
+        return
     output_dirs = [
         app_config.get("paths", {}).get("output_xmls", "data/output_xmls"),
         DEFAULT_CDA_FULL_OUTPUT_DIR,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,8 @@ def test_parse_args_log_level():
 def test_parse_args_log_level_default():
     args = parse_args([])
     assert args.log_level is None
+
+
+def test_parse_args_csv_to_json():
+    args = parse_args(["--csv-to-json", "in.csv"])
+    assert args.csv_to_json == "in.csv"

--- a/tests/test_csv_to_json.py
+++ b/tests/test_csv_to_json.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+from csv_to_xml_converter.utils import csv_to_json
+
+
+def test_convert_csv_to_json(tmp_path, monkeypatch):
+    csv_path = tmp_path / "sample.csv"
+    csv_path.write_text("a,b\n1,2\n3,4", encoding="utf-8")
+
+    config = {
+        "csv_profiles": {
+            "test": {"delimiter": ",", "encoding": "utf-8", "header": True}
+        }
+    }
+    cfg_path = tmp_path / "cfg.json"
+    cfg_path.write_text(json.dumps(config), encoding="utf-8")
+
+    monkeypatch.setattr(csv_to_json, "DEFAULT_CONFIG_FILE", str(cfg_path))
+    records = csv_to_json.convert_csv_to_json(str(csv_path), "test")
+
+    assert records == [{"a": "1", "b": "2"}, {"a": "3", "b": "4"}]
+    json_path = csv_path.with_suffix(".json")
+    loaded = json.loads(json_path.read_text(encoding="utf-8"))
+    assert loaded == records


### PR DESCRIPTION
## Summary
- implement `convert_csv_to_json` utility
- expose new utility in utils package
- add CLI option `--csv-to-json` and hook up GUI button
- include tests for new CLI parsing and csv->json helper
- document JSON conversion feature in README/README_JA

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880673558088333a50980cd0ac5705e