### PR TITLE
Remove CSV→JSON GUI button

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ The application is configured to look for XSDs in these specific locations. The 
     ```
     Use the interface to select the configuration JSON and specify the CSV profile.
     On Windows systems you can also launch the GUI by executing
-    `run_gui.bat` in the project root. A "CSV→JSON変換" button is provided to
-    export a single CSV to JSON using the chosen profile.
+    `run_gui.bat` in the project root.
 3.  Alternatively, run the CLI directly:
     ```bash
     python src/main.py [-c CONFIG] [-p PROFILE] [--log-level LEVEL]

--- a/README_JA.md
+++ b/README_JA.md
@@ -31,7 +31,6 @@ python src/gui.py
 
 画面から設定JSONとCSVプロファイルを指定して変換を実行します。
 Windows環境ではプロジェクトルートの `run_gui.bat` を実行することで同じGUIが起動します。
-GUIにはCSVをJSONに変換する「CSV→JSON変換」ボタンも用意されています。
 
 ### CLI
 

--- a/src/gui.py
+++ b/src/gui.py
@@ -34,9 +34,6 @@ class Application(tk.Tk):
         tk.Button(self, text="Run Conversion", command=self._run_conversion).grid(
             row=2, column=0, columnspan=3, pady=10
         )
-        tk.Button(self, text="CSV→JSON変換", command=self._run_csv_to_json).grid(
-            row=3, column=0, columnspan=3, pady=5
-        )
 
     def _browse_config(self):
         file_path = filedialog.askopenfilename(title="Select config file", filetypes=[("JSON", "*.json"), ("All", "*.*")])
@@ -52,21 +49,6 @@ class Application(tk.Tk):
             messagebox.showinfo("Success", "Conversion completed successfully.")
         except Exception as exc:
             messagebox.showerror("Error", f"An error occurred:\n{exc}")
-
-    def _run_csv_to_json(self):
-        csv_path = filedialog.askopenfilename(
-            title="Select CSV file", filetypes=[("CSV", "*.csv"), ("All", "*.*")]
-        )
-        if not csv_path:
-            return
-        config = self.config_entry.get().strip()
-        profile = self.profile_entry.get().strip()
-        try:
-            cli_main(["--config", config, "--profile", profile, "--csv-to-json", csv_path])
-            messagebox.showinfo("Success", "JSON file written next to CSV.")
-        except Exception as exc:
-            messagebox.showerror("Error", f"An error occurred:\n{exc}")
-
 
 if __name__ == "__main__":
     Application().mainloop()


### PR DESCRIPTION
## Summary
- remove obsolete `CSV→JSON変換` button from GUI
- delete unused `_run_csv_to_json` implementation
- update README and README_JA to drop button instructions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688075c743bc83339c628a84f66f9a36