### PR TITLE
Update README for automatic JSON generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The application is configured to look for XSDs in these specific locations. The 
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
-    * `--csv-to-json CSV` – parse the specified CSV and write the records to a JSON file, then exit.
+    * JSON data for each CSV is now written automatically during XML conversion, so there is no longer a separate conversion button or `--csv-to-json` option.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/README_JA.md
+++ b/README_JA.md
@@ -46,7 +46,7 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
-- `--csv-to-json CSV` : 指定したCSVを解析しJSONファイルとして保存して終了します。
+- CSVからXMLへ変換する際に解析結果のJSONも自動的に保存されるため、専用のボタンや`--csv-to-json`オプションは不要です。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
 テスト用にはリポジトリ直下に `TEST.csv` を同梱しています。以前の README で案内していた


### PR DESCRIPTION
## Summary
- remove docs for obsolete `--csv-to-json` flag
- add note that JSON is automatically produced during CSV to XML conversion

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807676a5f08333b67714b6652949c3