### PR TITLE
Remove convert_csv_to_json from utils init

### DIFF
--- a/src/csv_to_xml_converter/utils/__init__.py
+++ b/src/csv_to_xml_converter/utils/__init__.py
@@ -8,7 +8,6 @@ from typing import Optional, Union
 
 from lxml import etree
 
-from .csv_to_json import convert_csv_to_json
 
 logger = logging.getLogger(__name__)
 
@@ -32,4 +31,4 @@ def parse_xml(path: Union[str, PathLike[str]]) -> Optional[etree._ElementTree]:
     return None
 
 
-__all__ = ["parse_xml", "convert_csv_to_json"]
+__all__ = ["parse_xml"]


### PR DESCRIPTION
## Summary
- trim utils public API by removing `convert_csv_to_json`
- keep `parse_xml` exported

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880774904a88333837e5d948bcfe87a