### PR TITLE
Add JSON output for parsed CSVs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The application is configured to look for XSDs in these specific locations. The 
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
-    * JSON data for each CSV is now written automatically during XML conversion, so there is no longer a separate conversion button or `--csv-to-json` option.
+    * JSON data for each CSV is now written automatically during XML conversion. Parsed rows are saved to a file with the same name as the CSV but with a `.json` extension, so there is no longer a separate conversion button or `--csv-to-json` option.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/README_JA.md
+++ b/README_JA.md
@@ -46,7 +46,7 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
-- CSVからXMLへ変換する際に解析結果のJSONも自動的に保存されるため、専用のボタンや`--csv-to-json`オプションは不要です。
+- CSVからXMLへ変換する際、各CSVの解析結果は同名の`.json`ファイルとして自動的に保存されます。専用のボタンや`--csv-to-json`オプションは不要です。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
 テスト用にはリポジトリ直下に `TEST.csv` を同梱しています。以前の README で案内していた

--- a/src/csv_to_xml_converter/orchestrator/__init__.py
+++ b/src/csv_to_xml_converter/orchestrator/__init__.py
@@ -299,6 +299,15 @@ class Orchestrator:
                 logger.error(f"No data from {csv_file_path}")
                 return []
 
+            # Dump parsed CSV rows to a JSON file next to the CSV
+            json_path = Path(csv_file_path).with_suffix(".json")
+            try:
+                with open(json_path, "w", encoding="utf-8") as jf:
+                    json.dump(parsed_data_rows, jf, ensure_ascii=False, indent=2)
+                logger.info(f"Wrote parsed records to {json_path}")
+            except Exception as e_dump:
+                logger.error(f"Failed to write JSON output {json_path}: {e_dump}")
+
             rules = load_rules(rules_file_path)
             Path(output_xml_dir).mkdir(parents=True, exist_ok=True)
             logger.info(

--- a/tests/test_orchestrator_json_output.py
+++ b/tests/test_orchestrator_json_output.py
@@ -1,0 +1,39 @@
+import json
+from csv_to_xml_converter.orchestrator import Orchestrator
+
+
+def test_json_written(monkeypatch, tmp_path):
+    csv_file = tmp_path / "hc.csv"
+    csv_file.write_text("doc_id\nDOC1\n", encoding="utf-8")
+
+    rules_file = tmp_path / "hc_rules.json"
+    rules = [
+        {"rule_type": "direct_mapping", "input_field": "doc_id", "output_field": "documentIdExtension"}
+    ]
+    rules_file.write_text(json.dumps(rules), encoding="utf-8")
+
+    def fake_gen(obj):
+        return "<ClinicalDocument/>"
+
+    def fake_validate_write(self, xml_string, xsd_path, out_path, log_prefix, invalid_out_path=None):
+        out_path.write_text(xml_string, encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(
+        "csv_to_xml_converter.orchestrator.generate_health_checkup_cda", fake_gen
+    )
+    monkeypatch.setattr(
+        "csv_to_xml_converter.orchestrator.Orchestrator._validate_and_write_xml",
+        fake_validate_write,
+    )
+
+    orch = Orchestrator({"csv_profiles": {"hc": {"delimiter": ",", "encoding": "utf-8"}}})
+    out_dir = tmp_path / "out"
+    orch.process_csv_to_health_checkup_cdas(
+        str(csv_file), str(rules_file), "dummy.xsd", str(out_dir), csv_profile_name="hc"
+    )
+
+    json_path = csv_file.with_suffix(".json")
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data == [{"doc_id": "DOC1"}]


### PR DESCRIPTION
## Summary
- write parsed CSV records to adjacent `.json` files in `Orchestrator._process_csv_records`
- document automatic JSON output in README files
- add unit test for JSON generation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688079bdf64483338bd4cd189292ab59