### PR TITLE
Add configurable JSON output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The application is configured to look for XSDs in these specific locations. The 
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
-    * JSON data for each CSV is now written automatically during XML conversion. Parsed rows are saved to a file with the same name as the CSV but with a `.json` extension, so there is no longer a separate conversion button or `--csv-to-json` option.
+    * JSON data for each CSV is now written automatically during XML conversion. Parsed rows are saved as `.json` files. By default the JSON file is created next to the source CSV, but you can set `paths.json_output_dir` in the configuration to write them to a dedicated folder.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/README_JA.md
+++ b/README_JA.md
@@ -46,7 +46,7 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
-- CSVからXMLへ変換する際、各CSVの解析結果は同名の`.json`ファイルとして自動的に保存されます。専用のボタンや`--csv-to-json`オプションは不要です。
+- CSVからXMLへ変換する際、各CSVの解析結果は`.json`ファイルとして自動的に保存されます。デフォルトではCSVと同じ場所に出力されますが、設定ファイルの`paths.json_output_dir`を指定すると別ディレクトリに保存できます。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
 テスト用にはリポジトリ直下に `TEST.csv` を同梱しています。以前の README で案内していた

--- a/config_rules/config.json
+++ b/config_rules/config.json
@@ -3,6 +3,7 @@
     "xsd_schemas": "data/xsd_schemas/",
     "input_csvs": "data/input_csvs/",
     "output_xmls": "data/output_xmls/",
+    "json_output_dir": "data/json_outputs/",
     "xsd_source_path_for_archive": [
       "5521111111_00280081_202405271_1/XSD/",
       "XSD/"

--- a/src/csv_to_xml_converter/orchestrator/csv_processing.py
+++ b/src/csv_to_xml_converter/orchestrator/csv_processing.py
@@ -124,7 +124,15 @@ class CSVProcessingMixin:
                 logger.error(f"No data from {csv_file_path}")
                 return []
 
-            json_path = Path(csv_file_path).with_suffix(".json")
+            json_out_dir = (
+                self.config.get("paths", {}).get("json_output_dir")
+                or self.config.get("json_output_dir")
+            )
+            if json_out_dir:
+                Path(json_out_dir).mkdir(parents=True, exist_ok=True)
+                json_path = Path(json_out_dir) / (Path(csv_file_path).stem + ".json")
+            else:
+                json_path = Path(csv_file_path).with_suffix(".json")
             try:
                 with open(json_path, "w", encoding="utf-8") as jf:
                     json.dump(parsed_data_rows, jf, ensure_ascii=False, indent=2)

--- a/tests/test_orchestrator_json_output.py
+++ b/tests/test_orchestrator_json_output.py
@@ -148,3 +148,41 @@ def test_json_written_guidance_settlement(monkeypatch, tmp_path):
     assert json_path.exists()
     data = json.loads(json_path.read_text(encoding="utf-8"))
     assert data == [{"doc_id": "DOC1"}]
+
+
+def test_json_output_dir_config(monkeypatch, tmp_path):
+    csv_file = tmp_path / "hc.csv"
+    csv_file.write_text("doc_id\nDOC1\n", encoding="utf-8")
+
+    rules_file = tmp_path / "hc_rules.json"
+    rules = [
+        {"rule_type": "direct_mapping", "input_field": "doc_id", "output_field": "documentIdExtension"}
+    ]
+    rules_file.write_text(json.dumps(rules), encoding="utf-8")
+
+    def fake_gen(obj):
+        return "<ClinicalDocument/>"
+
+    def fake_validate_write(self, xml_string, xsd_path, out_path, log_prefix, invalid_out_path=None):
+        out_path.write_text(xml_string, encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(
+        "csv_to_xml_converter.orchestrator.generate_health_checkup_cda", fake_gen
+    )
+    monkeypatch.setattr(
+        "csv_to_xml_converter.orchestrator.Orchestrator._validate_and_write_xml",
+        fake_validate_write,
+    )
+
+    json_dir = tmp_path / "json_dir"
+    orch = Orchestrator({"csv_profiles": {"hc": {"delimiter": ",", "encoding": "utf-8"}}, "paths": {"json_output_dir": str(json_dir)}})
+    out_dir = tmp_path / "out"
+    orch.process_csv_to_health_checkup_cdas(
+        str(csv_file), str(rules_file), "dummy.xsd", str(out_dir), csv_profile_name="hc"
+    )
+
+    json_path = json_dir / "hc.json"
+    assert json_path.exists()
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    assert data == [{"doc_id": "DOC1"}]


### PR DESCRIPTION
## Summary
- support `json_output_dir` path in configuration
- update csv processing to write JSON files into this directory when set
- document the new option in README files
- test custom json output directory functionality

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e04181688333a5c877b412296efa