### PR TITLE
Clarify automatic JSON generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ The application is configured to look for XSDs in these specific locations. The 
     * `PROFILE` – name of the CSV profile defined in that config (defaults to `grouped_checkup_profile`)
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
-    * Users only provide CSV files; JSON files are generated automatically by the tool.
-    * JSON data for each CSV is now written automatically during XML conversion. Parsed rows are saved as `.json` files. By default the JSON file is created next to the source CSV, but you can set `paths.json_output_dir` in the configuration to write them to a dedicated folder.
+    * Users only provide CSV files. JSON data is produced automatically during conversion, so there is no need to upload or manually convert JSON.
+    * For each processed CSV a `.json` file is written automatically. By default this JSON file is created next to the source CSV, but you can set `paths.json_output_dir` in the configuration to write it to a dedicated folder.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in
     `config_rules/config.json`. Set `logging.console` or `logging.file` to `true`

--- a/README_JA.md
+++ b/README_JA.md
@@ -46,8 +46,8 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `PROFILE` : CSVプロファイル名 (デフォルト: `grouped_checkup_profile`)
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
-- ユーザーはCSVファイルだけを用意すればよく、JSONファイルをアップロードする必要はありません。ツールが自動で生成します。
-- CSVからXMLへ変換する際、各CSVの解析結果は`.json`ファイルとして自動的に保存されます。デフォルトではCSVと同じ場所に出力されますが、設定ファイルの`paths.json_output_dir`を指定すると別ディレクトリに保存できます。
+- ユーザーはCSVファイルだけを用意すれば十分です。変換時にJSONが自動生成されるため、JSONファイルをアップロードしたり手動で変換したりする必要はありません。
+- CSVからXMLへ変換する際、各CSVの解析結果は`.json`ファイルとして自動保存されます。デフォルトではCSVと同じ場所に出力されますが、設定ファイルの`paths.json_output_dir`を指定すると別ディレクトリに保存できます。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。
 テスト用にはリポジトリ直下に `TEST.csv` を同梱しています。以前の README で案内していた


### PR DESCRIPTION
## Summary
- note that users provide CSV files only
- mention automatic JSON output in docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68819b75b6a88333a330a937ffa9f7d3