### PR TITLE
Update specs for XSD and CSV usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ For the application to run correctly and perform XSD validations, the necessary 
 
 The application is configured to look for XSDs in these specific locations. The ZIP packaging process also sources XSDs from these directories, prioritizing `data/xsd_schemas_official/` for any overlapping file names (like `coreschemas/datatypes_hcgv08.xsd`).
 
+Only **one consolidated XSD set** is needed for validation. Treat this set as the rulebook for the conversion process.
+
 ## Usage
 
 1.  Install the dependencies listed in `requirements.txt` and ensure
@@ -110,6 +112,7 @@ The application is configured to look for XSDs in these specific locations. The 
     * `LEVEL` – optional logging level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`) to override the configuration
     * `--sample-test` – process CSV files from the bundled test data folders. Use `--sample-num-files` to control how many files are processed from each folder (default is 2). Combine with `--sample-only` to run only this lightweight test.
     * Users only provide CSV files. JSON data is produced automatically during conversion, so there is no need to upload or manually convert JSON.
+    * Place multiple CSV files under `data/input_csvs/`. All CSVs in this directory will be converted in a single run.
     * For each processed CSV a `.json` file is written automatically. By default this JSON file is created next to the source CSV, but you can set `paths.json_output_dir` in the configuration to write it to a dedicated folder.
 4.  Output XMLs will be generated in `data/output_xmls/` and ZIP archives in `data/output_archives/`.
 5.  Logs are written to the console and/or `logs/app.log` as specified in

--- a/README_JA.md
+++ b/README_JA.md
@@ -21,6 +21,7 @@ pip install -r requirements.txt
 ```
 
 XSDファイルは`data/xsd_schemas`および`data/xsd_schemas_official`以下に配置してください。
+検証に必要なXSDはこの1セットだけで十分です。ルールブックとして扱ってください。
 
 ## 使い方
 
@@ -48,6 +49,7 @@ python -m csv_to_xml_converter [-c CONFIG] [-p PROFILE] [--log-level LEVEL]
 - `LEVEL` : ログレベル (`DEBUG`, `INFO` など)
 - `--sample-test` : テスト用フォルダからCSVを処理します。 `--sample-num-files` で各フォルダから処理するファイル数を指定できます (デフォルト2)。 `--sample-only` を併用するとこの簡易テストのみを実行します。
 - ユーザーはCSVファイルだけを用意すれば十分です。変換時にJSONが自動生成されるため、JSONファイルをアップロードしたり手動で変換したりする必要はありません。
+- `data/input_csvs/` 配下に複数のCSVファイルを置くことで、一度の実行で全ファイルを変換できます。
 - CSVからXMLへ変換する際、各CSVの解析結果は`.json`ファイルとして自動保存されます。デフォルトではCSVと同じ場所に出力されますが、設定ファイルの`paths.json_output_dir`を指定すると別ディレクトリに保存できます。
 
 出力XMLは`data/output_xmls/`、ZIPアーカイブは`data/output_archives/`に生成されます。


### PR DESCRIPTION
## Summary
- clarify that the bundled XSD set acts as one rulebook
- mention support for multiple CSV files

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881cabc13308333834f244df3b98b76